### PR TITLE
Add conditional check for special characters in originalPath

### DIFF
--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -56,6 +56,7 @@ describe('convertASTToTemplateString - with out any modification options', () =>
 
     // Paths with Special Characters - not working
     `{{[@@#*&%$]}}`,
+    `{{[! " # % & ' ( ) * + , . / ; < = > @ ^ \` { | } ~]}}`,
 
     // Block Params
     `{{#each items as |item index|}} {{item}} {{index}} {{/each}}`,
@@ -445,6 +446,11 @@ describe('convertASTToTemplateString - with out any modification options', () =>
     `{{#each (filter undefined)}}...{{/each}}`,
     `{{join employees '/' lookup='name.first'}}`,
     `{{format_date "01-12-2022" format="MM/DD/YY" language=language}}`,
+    `{{#each (sort items lookup='undefined')}}...{{/each}}`,
+    `{{#each (sort items lookup='null')}}...{{/each}}`,
+    `{{#each (sort items lookup=null)}}...{{/each}}`,
+    `{{#each (sort items lookup=undefined)}}...{{/each}}`,
+
   ];
 
   for (const template of templates) {


### PR DESCRIPTION
- Add logic to check if originalPath contains special characters, is not a data variable, consists of a single part, and has zero path depth.
- Enhance code readability and validation logic.
- Handle expression such as 
   ```hbs
   {{#each (sort items lookup='undefined')}}...{{/each}}
   {{#each (sort items lookup='null')}}...{{/each}}
  ```